### PR TITLE
fixes setup fail due to encoding declaration on windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     name="django-openinghours",
     version=app.__version__,
     description=open('DESCRIPTION').read(),
-    long_description=open('README.rst').read(),
+    long_description=open('README.rst', 'r', encoding='utf-8').read(),
     license='The MIT License',
     platforms=['OS Independent'],
     keywords='django, app, openinghours, opening hours, opening times',


### PR DESCRIPTION
doing a pip install on windows throws out an error of unicodedecodeerror since it's trying to decode the file using cp1252 instead of utf-8.

this change fixes it.